### PR TITLE
fix previous commit breaking bluetooth state change observer

### DIFF
--- a/lmbluetoothsdk/src/main/java/co/lujun/lmbluetoothsdk/service/BluetoothService.java
+++ b/lmbluetoothsdk/src/main/java/co/lujun/lmbluetoothsdk/service/BluetoothService.java
@@ -356,13 +356,11 @@ public class BluetoothService {
             int bytes;
             while (true) {
                 try {
-                    if (mmInStream.available()>0) {
-                        bytes = mmInStream.read(buffer);
-                        if (bytes>0) {
-                            byte[] data = Arrays.copyOf(buffer,bytes);
-                            if (mBluetoothListener != null) {
-                                ((BluetoothListener) mBluetoothListener).onReadData(mmSocket.getRemoteDevice(), data);
-                            }
+                    bytes = mmInStream.read(buffer);
+                    if (bytes > 0) {
+                        byte[] data = Arrays.copyOf(buffer, bytes);
+                        if (mBluetoothListener != null) {
+                            ((BluetoothListener) mBluetoothListener).onReadData(mmSocket.getRemoteDevice(), data);
                         }
                     }
                 } catch (IOException e) {


### PR DESCRIPTION
the exception thrown at `mmInStream.read` was what caused the `STATE_DISCONNECTED` event to fire. The `if (mmInStream.available()>0)` made sure that the exception was not thrown, so inadvertently breaking that functionality.